### PR TITLE
Up to exercise 4: Move components out of App

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,11 +1,4 @@
 <script setup lang="ts">
-type Todo = {
-  userId: number;
-  id: number;
-  title: string;
-  completed: boolean;
-};
-
 type Photo = {
   albumId: number;
   id: number;
@@ -13,23 +6,6 @@ type Photo = {
   url: string;
   thumbnailUrl: string;
 };
-
-const todoList = ref<Todo[]>([]);
-const numTodoItems = computed(() => {
-  return todoList.value.length;
-});
-const numCompletedTodos = computed(() => {
-  return todoList.value.filter((todo) => todo.completed).length;
-});
-const percentageCompletedTodos = computed(() => {
-  return Math.round((numCompletedTodos.value / numTodoItems.value) * 100);
-});
-
-function fetchTodoList() {
-  fetch('https://jsonplaceholder.typicode.com/todos/').then(async (response) => {
-    todoList.value = await response.json();
-  });
-}
 
 const photoList = ref<Photo[]>([]);
 const numPhotos = computed(() => {
@@ -72,25 +48,7 @@ function fetchPhotoList() {
     </div>
     <h1 class="is-size-1">Hello Nuxt</h1>
     <div class="section">
-      <details>
-        <summary>TODOS</summary>
-        <button @click="fetchTodoList">Fetch Todos</button>
-        <details>
-          <summary>All todos</summary>
-          <pre>{{ todoList }}</pre>
-        </details>
-
-        <p v-if="numCompletedTodos">
-          {{ numCompletedTodos }} / {{ numTodoItems }} todos completed ({{
-            percentageCompletedTodos
-          }}%)
-        </p>
-        <ul class="grid is-col-min-14">
-          <li class="list-none" v-for="todo in todoList.slice(0, 20)" :key="todo.id">
-            <input disabled type="checkbox" :checked="todo.completed" /> {{ todo.title }}
-          </li>
-        </ul>
-      </details>
+      <TodoViewer />
     </div>
     <div class="section">
       <details>
@@ -118,7 +76,7 @@ function fetchPhotoList() {
 @use './assets/styles/main.scss';
 </style>
 
-<style scoped>
+<style>
 .list-none {
   list-style-type: none;
 }

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,32 +1,4 @@
-<script setup lang="ts">
-type Photo = {
-  albumId: number;
-  id: number;
-  title: string;
-  url: string;
-  thumbnailUrl: string;
-};
-
-const photoList = ref<Photo[]>([]);
-const numPhotos = computed(() => {
-  return photoList.value.length;
-});
-const numOddAlbums = computed(() => {
-  return photoList.value.filter((photo) => photo.albumId % 2 !== 0).length;
-});
-const numEvenAlbums = computed(() => {
-  return photoList.value.filter((photo) => photo.albumId % 2 === 0).length;
-});
-const percentageEvenAlbums = computed(() => {
-  return Math.round((numEvenAlbums.value / numPhotos.value) * 100);
-});
-
-function fetchPhotoList() {
-  fetch('https://jsonplaceholder.typicode.com/photos/').then(async (response) => {
-    photoList.value = await response.json();
-  });
-}
-</script>
+<script setup lang="ts"></script>
 
 <template>
   <div class="container">
@@ -51,22 +23,7 @@ function fetchPhotoList() {
       <TodoViewer />
     </div>
     <div class="section">
-      <details>
-        <summary>PHOTOS</summary>
-        <button @click="fetchPhotoList">Fetch photos</button>
-        <p v-if="numPhotos">
-          {{ numPhotos }} photos total ({{ numOddAlbums }} odd, {{ numEvenAlbums }} even ({{
-            percentageEvenAlbums
-          }}%))
-        </p>
-        <div class="fixed-grid has-5-cols">
-          <ul class="grid">
-            <li class="list-none" v-for="photo in photoList.slice(0, 10)" :key="photo.id">
-              <img :src="photo.thumbnailUrl" :alt="photo.title" />
-            </li>
-          </ul>
-        </div>
-      </details>
+      <PhotoGallery />
     </div>
   </div>
 </template>

--- a/app/app.vue
+++ b/app/app.vue
@@ -122,8 +122,4 @@ function fetchPhotoList() {
 .list-none {
   list-style-type: none;
 }
-
-.mw-300 {
-  min-width: 300px;
-}
 </style>

--- a/app/app.vue
+++ b/app/app.vue
@@ -20,7 +20,9 @@
     </div>
     <h1 class="is-size-1">Hello Nuxt</h1>
     <div class="section">
-      <TodoViewer />
+      <TodoViewer>
+        <template #header="{ completed, total, percent }"> {{ completed }} / {{ total }} </template>
+      </TodoViewer>
     </div>
     <div class="section">
       <PhotoGallery />

--- a/app/components/BaseGallery.vue
+++ b/app/components/BaseGallery.vue
@@ -1,0 +1,60 @@
+<script lang="ts" setup generic="TItem extends {id: string | number}, TMetricsKey extends string">
+/** Using this type prevents 'total' from being used as a key */ 
+export type Metrics<TItem> = Record<string, (item: TItem) => boolean> & { total?: never };
+
+type Props = {
+  fetchButtonText: string;
+  fetchUrl: string;
+  metrics: Record<TMetricsKey, (item: TItem) => boolean>;
+};
+const props = defineProps<Props>();
+
+const list = ref<TItem[]>([]);
+
+const metrics = computed(() =>
+  list.value.reduce(
+    (tracker, item) => {
+      for (const key in props.metrics) {
+        const success = props.metrics[key](item as TItem);
+        if (success) {
+          if (tracker[key as TMetricsKey]) {
+            tracker[key as TMetricsKey] += 1;
+          } else {
+            tracker[key as TMetricsKey] = 1;
+          }
+        }
+      }
+      return tracker;
+    },
+    { total: list.value.length } as Record<TMetricsKey | 'total', number>
+  )
+);
+
+function fetchList() {
+  fetch(props.fetchUrl).then(async (response) => {
+    list.value = await response.json();
+  });
+}
+</script>
+
+<template>
+  <details class="box">
+    <summary class="button">
+      <slot name="summary">SHOW LIST</slot>
+    </summary>
+
+    <button @click="fetchList" class="button m-2">{{ fetchButtonText }}</button>
+    <details>
+      <summary class="button">Show all data</summary>
+      <pre>{{ list }}</pre>
+    </details>
+
+    <slot v-if="list.length" name="header" :metrics="metrics">LIST</slot>
+
+    <ul class="grid is-col-min-14">
+      <li class="list-none" v-for="item in list.slice(0, 20)" :key="item.id">
+        <slot name="list-item" :item="item" />
+      </li>
+    </ul>
+  </details>
+</template>

--- a/app/components/PhotoGallery.vue
+++ b/app/components/PhotoGallery.vue
@@ -1,0 +1,48 @@
+<script lang="ts" setup>
+type Photo = {
+  albumId: number;
+  id: number;
+  title: string;
+  url: string;
+  thumbnailUrl: string;
+};
+
+const photoList = ref<Photo[]>([]);
+const numPhotos = computed(() => {
+  return photoList.value.length;
+});
+const numOddAlbums = computed(() => {
+  return photoList.value.filter((photo) => photo.albumId % 2 !== 0).length;
+});
+const numEvenAlbums = computed(() => {
+  return photoList.value.filter((photo) => photo.albumId % 2 === 0).length;
+});
+const percentageEvenAlbums = computed(() => {
+  return Math.round((numEvenAlbums.value / numPhotos.value) * 100);
+});
+
+function fetchPhotoList() {
+  fetch('https://jsonplaceholder.typicode.com/photos/').then(async (response) => {
+    photoList.value = await response.json();
+  });
+}
+</script>
+
+<template>
+  <details>
+    <summary>PHOTOS</summary>
+    <button @click="fetchPhotoList">Fetch photos</button>
+    <p v-if="numPhotos">
+      {{ numPhotos }} photos total ({{ numOddAlbums }} odd, {{ numEvenAlbums }} even ({{
+        percentageEvenAlbums
+      }}%))
+    </p>
+    <div class="fixed-grid has-5-cols">
+      <ul class="grid">
+        <li class="list-none" v-for="photo in photoList.slice(0, 10)" :key="photo.id">
+          <img :src="photo.thumbnailUrl" :alt="photo.title" />
+        </li>
+      </ul>
+    </div>
+  </details>
+</template>

--- a/app/components/TodoViewer.vue
+++ b/app/components/TodoViewer.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import type { Metrics } from './BaseGallery.vue';
+
 type Todo = {
   userId: number;
   id: number;
@@ -6,52 +8,28 @@ type Todo = {
   completed: boolean;
 };
 
-const todoList = ref<Todo[]>([]);
-const numTodoItems = computed(() => {
-  return todoList.value.length;
-});
-const numCompletedTodos = computed(() => {
-  return todoList.value.filter((todo) => todo.completed).length;
-});
-const percentageCompletedTodos = computed(() => {
-  return Math.round((numCompletedTodos.value / numTodoItems.value) * 100);
-});
-
-function fetchTodoList() {
-  fetch('https://jsonplaceholder.typicode.com/todos/').then(async (response) => {
-    todoList.value = await response.json();
-  });
-}
+// `as const` allows keys to be inferred as literals instead of `string`
+// `satisfies` gives type checking/inference within this object
+const metrics = {
+  completed: (todo) => todo.completed,
+} as const satisfies Metrics<Todo>;
 </script>
 
 <template>
-  <details>
-    <summary>TODOS</summary>
-    <button @click="fetchTodoList">Fetch Todos</button>
-    <details>
-      <summary>All todos</summary>
-      <pre>{{ todoList }}</pre>
-    </details>
+  <BaseGallery
+    :metrics="metrics"
+    fetch-button-text="Get TODOs"
+    fetch-url="https://jsonplaceholder.typicode.com/todos/"
+  >
+    <template #summary> Show TODOs </template>
 
-    <slot
-      name="header"
-      v-if="numCompletedTodos"
-      :completed="numCompletedTodos"
-      :total="numTodoItems"
-      :percent="percentageCompletedTodos"
-    >
-      <p>
-        {{ numCompletedTodos }} / {{ numTodoItems }} todos completed ({{
-          percentageCompletedTodos
-        }}%)
-      </p>
-    </slot>
+    <template #header="{ metrics }">
+      <span class="is-size-4"> TODOs ({{ metrics.completed }} / {{ metrics.total }}) </span>
+    </template>
 
-    <ul class="grid is-col-min-14">
-      <li class="list-none" v-for="todo in todoList.slice(0, 20)" :key="todo.id">
-        <input disabled type="checkbox" :checked="todo.completed" />
-        {{ todo.title }}
-      </li>
-    </ul>
-  </details>
+    <template #list-item="{ item: todo }">
+      <input disabled type="checkbox" :checked="todo.completed" />
+      {{ todo.title }}
+    </template>
+  </BaseGallery>
 </template>

--- a/app/components/TodoViewer.vue
+++ b/app/components/TodoViewer.vue
@@ -1,0 +1,54 @@
+<script lang="ts" setup>
+type Todo = {
+  userId: number;
+  id: number;
+  title: string;
+  completed: boolean;
+};
+
+const todoList = ref<Todo[]>([]);
+const numTodoItems = computed(() => {
+  return todoList.value.length;
+});
+const numCompletedTodos = computed(() => {
+  return todoList.value.filter((todo) => todo.completed).length;
+});
+const percentageCompletedTodos = computed(() => {
+  return Math.round((numCompletedTodos.value / numTodoItems.value) * 100);
+});
+
+function fetchTodoList() {
+  fetch("https://jsonplaceholder.typicode.com/todos/").then(
+    async (response) => {
+      todoList.value = await response.json();
+    }
+  );
+}
+</script>
+
+<template>
+  <details>
+    <summary>TODOS</summary>
+    <button @click="fetchTodoList">Fetch Todos</button>
+    <details>
+      <summary>All todos</summary>
+      <pre>{{ todoList }}</pre>
+    </details>
+
+    <p v-if="numCompletedTodos">
+      {{ numCompletedTodos }} / {{ numTodoItems }} todos completed ({{
+        percentageCompletedTodos
+      }}%)
+    </p>
+    <ul class="grid is-col-min-14">
+      <li
+        class="list-none"
+        v-for="todo in todoList.slice(0, 20)"
+        :key="todo.id"
+      >
+        <input disabled type="checkbox" :checked="todo.completed" />
+        {{ todo.title }}
+      </li>
+    </ul>
+  </details>
+</template>

--- a/app/components/TodoViewer.vue
+++ b/app/components/TodoViewer.vue
@@ -18,11 +18,9 @@ const percentageCompletedTodos = computed(() => {
 });
 
 function fetchTodoList() {
-  fetch("https://jsonplaceholder.typicode.com/todos/").then(
-    async (response) => {
-      todoList.value = await response.json();
-    }
-  );
+  fetch('https://jsonplaceholder.typicode.com/todos/').then(async (response) => {
+    todoList.value = await response.json();
+  });
 }
 </script>
 
@@ -35,17 +33,22 @@ function fetchTodoList() {
       <pre>{{ todoList }}</pre>
     </details>
 
-    <p v-if="numCompletedTodos">
-      {{ numCompletedTodos }} / {{ numTodoItems }} todos completed ({{
-        percentageCompletedTodos
-      }}%)
-    </p>
+    <slot
+      name="header"
+      v-if="numCompletedTodos"
+      :completed="numCompletedTodos"
+      :total="numTodoItems"
+      :percent="percentageCompletedTodos"
+    >
+      <p>
+        {{ numCompletedTodos }} / {{ numTodoItems }} todos completed ({{
+          percentageCompletedTodos
+        }}%)
+      </p>
+    </slot>
+
     <ul class="grid is-col-min-14">
-      <li
-        class="list-none"
-        v-for="todo in todoList.slice(0, 20)"
-        :key="todo.id"
-      >
+      <li class="list-none" v-for="todo in todoList.slice(0, 20)" :key="todo.id">
         <input disabled type="checkbox" :checked="todo.completed" />
         {{ todo.title }}
       </li>


### PR DESCRIPTION
Moves components out of app, then consolidates common logic into `BaseGallery`.

The course suggests lifting the state for each type into the parent component wrapping `BaseGallery`, but "metrics config" objects and generic types can be used to keep the state within `BaseGallery` and still support inference when defining slot templates in parent components.